### PR TITLE
Add missing return after WriteError in both create.go and index.go

### DIFF
--- a/handlers/links/create.go
+++ b/handlers/links/create.go
@@ -35,6 +35,7 @@ func (h PostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err = h.insertLinks(r.Context(), link, sublinks)
 	if err != nil {
 		e.WriteError(w, http.StatusInternalServerError, err)
+		return
 	}
 
 	handlers.WriteResponse(w, http.StatusCreated, *link)

--- a/handlers/links/index.go
+++ b/handlers/links/index.go
@@ -33,6 +33,7 @@ func (h IndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	links, err := getUserLinks(ctx, h.DB, userID, r.FormValue("sort_by"))
 	if err != nil {
 		e.WriteError(w, http.StatusInternalServerError, err)
+		return
 	}
 
 	handlers.WriteResponse(w, http.StatusOK, links)


### PR DESCRIPTION
Hotfix
Add missing 'return' after WriteError to exit handler upon logging the error message